### PR TITLE
Redesign new game onboarding: region selection + init overlay

### DIFF
--- a/db/models/Plot.js
+++ b/db/models/Plot.js
@@ -8,6 +8,11 @@ const Plot = new Schema(
             ref: 'World',
             required: true
         },
+        status: {
+            type: String,
+            enum: ['created', 'initializing', 'ready', 'error'],
+            default: 'created'
+        },
         players: [
             {
                 user: {
@@ -204,7 +209,8 @@ const Plot = new Schema(
             causedBy: String, // What action caused this
             timestamp: { type: Date, default: Date.now }
         }]
-    }
+    },
+    { timestamps: true }
 );
 
 module.exports = mongoose.model('Plot', Plot);

--- a/db/models/Settlement.js
+++ b/db/models/Settlement.js
@@ -94,7 +94,8 @@ const Settlement = new Schema(
         image: String,
         // NEW: Internal locations within the settlement
         locations: [LocationSchema],
-        locationsGenerated: { type: Boolean, default: false }
+        locationsGenerated: { type: Boolean, default: false },
+        layoutComputed: { type: Boolean, default: false }
     }
 );
 

--- a/public/index.html
+++ b/public/index.html
@@ -48,22 +48,23 @@
             
             <!-- Quick Actions -->
             <div id="quick-actions">
-                <button class="quick-action" data-action="I look around carefully" data-type="action">👀 Look</button>
-                <button class="quick-action" data-action="I approach someone nearby and greet them" data-type="speak">💬 Talk</button>
-                <button class="quick-action" data-action="I check my belongings and inventory" data-type="action">🎒 Inv</button>
-                <button class="quick-action" data-action="I find a safe spot to rest and catch my breath" data-type="action">💤 Rest</button>
+                <div id="dynamic-actions">
+                    <button class="quick-action dynamic-action" data-action="I approach someone nearby and greet them">💬 Talk</button>
+                    <button class="quick-action dynamic-action" data-action="I check my belongings and inventory">🎒 Inventory</button>
+                    <button class="quick-action dynamic-action" data-action="I explore the area further">🔍 Explore</button>
+                </div>
+                <div id="static-actions">
+                    <button class="quick-action static-action" data-action="I look around carefully">👀 Look</button>
+                    <button class="quick-action static-action" data-action="I find a safe spot to rest and catch my breath">💤 Rest</button>
+                </div>
             </div>
-            
+
             <!-- Input Area -->
             <div id="input-area">
-                <div id="input-selector">
-                    <label><input type="radio" name="inputType" value="action" checked> Action</label>
-                    <label><input type="radio" name="inputType" value="speak"> Speak</label>
-                    <label><input type="radio" name="inputType" value="askGM"> Ask GM</label>
-                </div>
                 <div id="input-row">
-                    <input id="chat-box" type="text" placeholder="What do you do?">
-                    <button id="submit-btn">→</button>
+                    <input id="chat-box" type="text" placeholder="What do you do? (actions, speech, or both)">
+                    <button id="submit-btn">Send</button>
+                    <button id="ask-gm-btn" title="Step out of character to ask the Game Master a question about how the game works">?</button>
                 </div>
             </div>
         </div>
@@ -180,6 +181,21 @@
     <div class="modal-content">
         <span class="close" id="close-settlement-modal">&times;</span>
         <div id="settlement-details"></div>
+    </div>
+</div>
+
+<!-- Game Init Overlay -->
+<div id="game-init-overlay" style="display: none;">
+    <div class="init-overlay-content">
+        <div class="init-dragon-icon">&#x1F409;</div>
+        <h2 class="init-title">Preparing Your Adventure</h2>
+        <div class="init-progress-container">
+            <div class="init-progress-bar">
+                <div id="init-progress-fill" class="init-progress-fill"></div>
+            </div>
+            <p id="init-progress-message" class="init-message">Connecting to the world...</p>
+        </div>
+        <button id="init-retry-btn" class="btn-primary" style="display: none;">Retry</button>
     </div>
 </div>
 

--- a/public/map-styles.css
+++ b/public/map-styles.css
@@ -50,7 +50,7 @@
   padding: 20px;
   overflow-y: auto;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
 }
 
@@ -161,18 +161,113 @@
   font-size: 12px;
 }
 
-.map-graph {
-  max-width: 100%;
+/* Settlement SVG Map */
+.settlement-map-container {
+  width: 100%;
+  max-width: 380px;
+  margin: 0 auto;
+}
+
+.settlement-map {
+  width: 100%;
   height: auto;
+  display: block;
 }
 
-.location-node {
-  transition: all 0.3s;
+.map-bg {
+  fill: #0d1117;
+  stroke: #1a2e3e;
+  stroke-width: 2;
 }
 
-.location-node:not(.current):hover {
+/* Roads */
+.road {
+  stroke: #8B7355;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.road.fog-road {
+  stroke: #8B7355;
+  stroke-width: 1.5;
+  stroke-dasharray: 6 4;
+  opacity: 0.35;
+}
+
+/* Fog nodes (undiscovered) */
+.fog-circle {
+  fill: #1a1a2e;
+  stroke: #444;
+  stroke-width: 1.5;
+  stroke-dasharray: 3 3;
+  opacity: 0.5;
+}
+
+.fog-label {
+  fill: #666;
+  font-size: 14px;
+  font-weight: bold;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+/* Location markers */
+.location-marker {
+  cursor: pointer;
+}
+
+.location-marker:hover .marker {
   filter: brightness(1.3);
-  transform: scale(1.1);
+}
+
+.location-marker:hover .marker-label {
+  fill: #fff;
+}
+
+.marker {
+  stroke: #222;
+  stroke-width: 2;
+  transition: filter 0.2s;
+}
+
+.marker.current {
+  stroke: #4CAF50;
+  stroke-width: 2.5;
+}
+
+.marker.connected {
+  stroke: #6366f1;
+  stroke-width: 2;
+}
+
+/* Current location glow */
+.current-glow {
+  fill: none;
+  stroke: #4CAF50;
+  stroke-width: 2;
+  opacity: 0.6;
+  animation: glow-pulse 2s ease-in-out infinite;
+}
+
+@keyframes glow-pulse {
+  0%, 100% { opacity: 0.3; r: 20; }
+  50% { opacity: 0.7; r: 24; }
+}
+
+/* Marker icon (emoji) */
+.marker-icon {
+  font-size: 14px;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+/* Marker label (name) */
+.marker-label {
+  fill: #aaa;
+  font-size: 10px;
+  text-anchor: middle;
+  pointer-events: none;
+  font-family: inherit;
 }
 
 /* Scene View (POI List) */
@@ -375,8 +470,8 @@
     border-top: 2px solid #0f3460;
   }
 
-  .map-graph {
-    width: 100%;
+  .settlement-map-container {
+    max-width: 100%;
   }
 
   .poi-card {

--- a/public/profile.html
+++ b/public/profile.html
@@ -160,6 +160,19 @@
         </div>
     </div>
 
+    <div id="region-selection-modal" class="modal" style="display: none;">
+        <div class="modal-content region-selection-content">
+            <span class="close">&times;</span>
+            <h3>Choose Your Starting Region</h3>
+            <p class="region-selection-subtitle">Where will your adventure begin?</p>
+            <div id="region-cards-loading" class="region-loading">
+                <div class="loader"></div>
+                <p>Preparing adventure hooks...</p>
+            </div>
+            <div id="region-cards" class="region-cards-grid"></div>
+        </div>
+    </div>
+
     <div id="loading-spinner" class="spinner" style="display: none;">
         <div class="spinner-content">
             <div class="loader"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -250,11 +250,25 @@ body {
 
 #quick-actions {
   display: flex;
-  gap: 8px;
+  justify-content: space-between;
+  align-items: center;
   padding: 12px 16px;
   background: var(--bg-panel);
   border-top: 1px solid var(--border-subtle);
+  gap: 12px;
+}
+
+#dynamic-actions {
+  display: flex;
+  gap: 8px;
   flex-wrap: wrap;
+  flex: 1;
+}
+
+#static-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .quick-action {
@@ -267,6 +281,7 @@ body {
   cursor: pointer;
   transition: all 0.2s ease;
   font-family: 'Inter', sans-serif;
+  white-space: nowrap;
 }
 
 .quick-action:hover {
@@ -280,6 +295,33 @@ body {
   transform: translateY(0);
 }
 
+.quick-action.dynamic-action {
+  border-color: rgba(212, 175, 55, 0.4);
+  transition: all 0.3s ease;
+}
+
+.quick-action.dynamic-action:hover {
+  border-color: var(--accent-indigo);
+}
+
+.quick-action.static-action {
+  opacity: 0.8;
+}
+
+.quick-action.static-action:hover {
+  opacity: 1;
+}
+
+.quick-action.dynamic-updating {
+  animation: dynamicPop 0.5s ease;
+}
+
+@keyframes dynamicPop {
+  0% { transform: scale(0.9); opacity: 0.5; }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
 /* ============================================
    INPUT AREA
    ============================================ */
@@ -290,23 +332,35 @@ body {
   border-top: 1px solid var(--border-subtle);
 }
 
-#input-selector {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 10px;
-}
-
-#input-selector label {
-  font-size: 0.8rem;
-  color: var(--text-secondary);
+#ask-gm-btn {
+  padding: 12px 16px;
+  font-size: 1rem;
+  background: var(--bg-input);
+  color: var(--accent-indigo);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  transition: all 0.2s ease;
+  font-weight: 700;
 }
 
-#input-selector input[type="radio"] {
-  accent-color: var(--accent-indigo);
+#ask-gm-btn:hover {
+  background: var(--accent-indigo);
+  color: var(--bg-primary);
+  border-color: var(--accent-indigo);
+}
+
+.tool-status {
+  font-size: 0.85rem;
+  color: var(--accent-gold);
+  font-style: italic;
+  padding: 2px 0;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
 }
 
 #input-row {
@@ -715,6 +769,15 @@ body {
 
   .message {
     max-width: 95%;
+  }
+
+  #quick-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  #dynamic-actions, #static-actions {
+    justify-content: center;
   }
 
   .quick-action {
@@ -1177,29 +1240,238 @@ body {
   margin-top: 8px;
 }
 
+/* ============================================
+   REGION SELECTION CARDS
+   ============================================ */
+
+.region-selection-content {
+  max-width: 900px;
+}
+
+.region-selection-subtitle {
+  color: var(--text-secondary);
+  margin-bottom: 24px;
+  font-size: 1rem;
+}
+
+.region-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 40px;
+  color: var(--text-secondary);
+}
+
+.region-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.region-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-left: 4px solid var(--accent-indigo);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.region-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--accent-gold);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  background: var(--bg-input);
+}
+
+.region-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.region-card-header h4 {
+  font-family: 'Crimson Text', serif;
+  font-size: 1.2rem;
+  color: var(--accent-gold);
+  margin: 0;
+}
+
+.region-ecosystem {
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+  border-radius: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.region-short {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+.region-hook {
+  color: var(--accent-gold);
+  font-family: 'Crimson Text', serif;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  opacity: 0.9;
+  min-height: 1.4em;
+}
+
+.hook-loading {
+  color: var(--text-muted);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+/* ============================================
+   GAME INIT OVERLAY
+   ============================================ */
+
+#game-init-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 40%, #16213e 100%);
+  z-index: 10000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: opacity 0.6s ease;
+}
+
+#game-init-overlay.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.init-overlay-content {
+  text-align: center;
+  max-width: 500px;
+  padding: 40px;
+}
+
+.init-dragon-icon {
+  font-size: 4rem;
+  margin-bottom: 24px;
+  animation: breathe 3s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  0%, 100% { transform: scale(1); opacity: 0.8; }
+  50% { transform: scale(1.1); opacity: 1; }
+}
+
+.init-title {
+  font-family: 'Crimson Text', serif;
+  font-size: 2rem;
+  color: var(--accent-gold);
+  margin-bottom: 32px;
+}
+
+.init-progress-container {
+  width: 100%;
+}
+
+.init-progress-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--bg-input);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.init-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent-indigo), var(--accent-gold));
+  border-radius: 3px;
+  transition: width 0.5s ease;
+}
+
+.init-message {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  margin-bottom: 24px;
+  min-height: 24px;
+}
+
+/* ============================================
+   SPINNER / LOADER
+   ============================================ */
+
+.spinner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 9000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.spinner-content {
+  text-align: center;
+  color: var(--text-primary);
+}
+
+.loader {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--border-subtle);
+  border-top: 4px solid var(--accent-gold);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto 16px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Mobile Responsive */
 @media (max-width: 768px) {
   .landing-logo h1 {
     font-size: 2.5rem;
   }
-  
+
   .dragon-icon {
     font-size: 2.5rem;
   }
-  
+
   .landing-features {
     grid-template-columns: 1fr;
   }
-  
+
   .profile-header-content {
     flex-direction: column;
     gap: 16px;
   }
-  
+
   .card-header {
     flex-direction: column;
     align-items: flex-start;
     gap: 16px;
+  }
+
+  .region-cards-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/services/discoveryService.js
+++ b/services/discoveryService.js
@@ -11,6 +11,7 @@ const Plot = require('../db/models/Plot');
 const Settlement = require('../db/models/Settlement');
 const settlementsFactory = require('../agents/world/factories/settlementsFactory');
 const { simplePrompt } = require('./gptService');
+const { sanitizeDirection } = require('./layoutService');
 
 /**
  * Parse an AI response for discoveries (NPCs, objects, locations)
@@ -153,7 +154,7 @@ IMPORTANT: Only include things with PROPER NAMES. Skip generic descriptions like
                         location.connections = location.connections || [];
                         location.connections.push({
                             locationName: newLoc.name,
-                            direction: newLoc.direction || 'nearby',
+                            direction: sanitizeDirection(newLoc.direction),
                             description: newLoc.description || ''
                         });
                         

--- a/services/gameAgent.js
+++ b/services/gameAgent.js
@@ -1,0 +1,561 @@
+/**
+ * Game Agent - AI with tool-calling for grounded game responses
+ *
+ * Flow:
+ * 1. Player sends input
+ * 2. AI decides which tools to call (fast, non-streaming)
+ * 3. Tools execute against the database
+ * 4. AI generates narrative with tool results as context (streaming)
+ */
+
+const Plot = require('../db/models/Plot');
+const Settlement = require('../db/models/Settlement');
+const GameLog = require('../db/models/GameLog');
+const { OpenAI } = require('openai');
+const { buildSystemPrompt, GAME_MODEL } = require('./gptService');
+
+require('dotenv').config();
+
+const openai = new OpenAI({ project: process.env.DRAGONS_PROJECT });
+
+// ============ TOOL DEFINITIONS ============
+
+const TOOLS = [
+    {
+        type: "function",
+        function: {
+            name: "get_scene",
+            description: "Get details about the player's current location: what the place looks like, who is present, available exits, and notable objects. Call this to understand what's around the player.",
+            parameters: { type: "object", properties: {}, required: [] }
+        }
+    },
+    {
+        type: "function",
+        function: {
+            name: "lookup_npc",
+            description: "Look up a specific NPC by name to get their attitude toward the player and past interactions. Use when the player talks to, asks about, or interacts with a named character.",
+            parameters: {
+                type: "object",
+                properties: {
+                    name: { type: "string", description: "Name or partial name of the NPC" }
+                },
+                required: ["name"]
+            }
+        }
+    },
+    {
+        type: "function",
+        function: {
+            name: "move_player",
+            description: "Move the player to a connected location. ONLY call when the player explicitly wants to go somewhere (e.g. 'I go to the market', 'I head north'). Do NOT call for small movements within the same location.",
+            parameters: {
+                type: "object",
+                properties: {
+                    destination: { type: "string", description: "Name of the location to move to" }
+                },
+                required: ["destination"]
+            }
+        }
+    },
+    {
+        type: "function",
+        function: {
+            name: "update_npc_relationship",
+            description: "Update an NPC's attitude toward the player after a significant interaction. Only call when something meaningful changes the relationship (insult, help, betrayal, gift, etc).",
+            parameters: {
+                type: "object",
+                properties: {
+                    npc_name: { type: "string", description: "The NPC's name" },
+                    new_disposition: {
+                        type: "string",
+                        enum: ["hostile", "unfriendly", "neutral", "friendly", "allied"],
+                        description: "New attitude"
+                    },
+                    reason: { type: "string", description: "Brief reason for change" }
+                },
+                required: ["npc_name", "new_disposition", "reason"]
+            }
+        }
+    }
+];
+
+// ============ TOOL EXECUTION ============
+
+async function executeGetScene(plotId) {
+    const plot = await Plot.findById(plotId)
+        .populate('current_state.current_location.region')
+        .populate('current_state.current_location.settlement');
+
+    const settlement = plot.current_state?.current_location?.settlement;
+    const region = plot.current_state?.current_location?.region;
+
+    if (!settlement?.locations?.length) {
+        return {
+            location: 'Wilderness',
+            region: region?.name || 'Unknown',
+            description: region?.description || 'Open terrain.',
+            exits: [],
+            npcsPresent: [],
+            objects: []
+        };
+    }
+
+    // Find current location
+    const locationId = plot.current_state.current_location.locationId;
+    const locationName = plot.current_state.current_location.locationName;
+
+    let currentLoc = null;
+    if (locationId) {
+        currentLoc = settlement.locations.find(l => l._id.toString() === locationId.toString());
+    }
+    if (!currentLoc && locationName) {
+        currentLoc = settlement.locations.find(l => l.name.toLowerCase() === locationName.toLowerCase());
+    }
+    if (!currentLoc) {
+        currentLoc = settlement.locations.find(l => l.isStartingLocation) || settlement.locations[0];
+    }
+
+    if (!currentLoc) {
+        return { location: settlement.name, description: settlement.description || '', exits: [], npcsPresent: [], objects: [] };
+    }
+
+    const exits = (currentLoc.connections || []).map(conn => ({
+        direction: conn.direction,
+        name: conn.locationName,
+        via: conn.description || ''
+    }));
+
+    const npcsPresent = (currentLoc.pois || [])
+        .filter(p => p.discovered && p.type === 'npc')
+        .map(p => ({ name: p.name, description: p.description || '' }));
+
+    const objects = (currentLoc.pois || [])
+        .filter(p => p.discovered && p.type !== 'npc')
+        .map(p => ({ name: p.name, type: p.type, description: p.description || '' }));
+
+    return {
+        location: currentLoc.name,
+        locationType: currentLoc.type,
+        description: currentLoc.description || '',
+        settlement: settlement.name,
+        timeOfDay: plot.current_state.current_time || 'day',
+        activity: plot.current_state.current_activity || 'exploring',
+        exits,
+        npcsPresent,
+        objects
+    };
+}
+
+async function executeLookupNpc(plotId, npcName) {
+    const plot = await Plot.findById(plotId)
+        .populate('current_state.current_location.settlement');
+
+    // Check reputation records
+    const repNpc = (plot.reputation?.npcs || []).find(n =>
+        n.name.toLowerCase().includes(npcName.toLowerCase())
+    );
+
+    // Check POIs across settlement locations
+    const settlement = plot.current_state?.current_location?.settlement;
+    let poiNpc = null;
+    if (settlement?.locations) {
+        for (const loc of settlement.locations) {
+            const found = (loc.pois || []).find(p =>
+                p.type === 'npc' && p.name.toLowerCase().includes(npcName.toLowerCase())
+            );
+            if (found) {
+                poiNpc = { name: found.name, description: found.description, foundAt: loc.name, interactionCount: found.interactionCount };
+                break;
+            }
+        }
+    }
+
+    if (!repNpc && !poiNpc) {
+        return { found: false, name: npcName, note: 'Unknown NPC. This may be someone new — you can introduce them naturally.' };
+    }
+
+    return {
+        found: true,
+        name: repNpc?.name || poiNpc?.name || npcName,
+        disposition: repNpc?.disposition || 'neutral',
+        lastInteraction: repNpc?.lastInteraction || 'None recorded',
+        location: poiNpc?.foundAt || repNpc?.location || 'Unknown',
+        description: poiNpc?.description || '',
+        interactionCount: poiNpc?.interactionCount || 0
+    };
+}
+
+async function executeMovePlayer(plotId, destination) {
+    const movementService = require('./movementService');
+
+    const canMove = await movementService.canMoveTo(plotId, destination);
+    if (!canMove.valid) {
+        return { success: false, reason: canMove.reason || `Cannot reach "${destination}" from here.` };
+    }
+
+    const result = await movementService.moveToLocation(plotId, destination);
+    if (!result.success) {
+        return { success: false, reason: result.error || 'Movement failed.' };
+    }
+
+    return {
+        success: true,
+        newLocation: result.location?.name || destination,
+        narration: result.narration || `You arrive at ${destination}.`
+    };
+}
+
+async function executeUpdateRelationship(plotId, npcName, newDisposition, reason) {
+    const plot = await Plot.findById(plotId);
+    if (!plot.reputation) plot.reputation = { npcs: [], factions: [], locations: [] };
+    if (!plot.reputation.npcs) plot.reputation.npcs = [];
+
+    const existing = plot.reputation.npcs.find(n => n.name.toLowerCase() === npcName.toLowerCase());
+    if (existing) {
+        existing.disposition = newDisposition;
+        existing.lastInteraction = reason;
+    } else {
+        plot.reputation.npcs.push({
+            name: npcName,
+            disposition: newDisposition,
+            lastInteraction: reason,
+            location: plot.current_state?.current_location?.locationName || 'Unknown'
+        });
+    }
+
+    await plot.save();
+    return { updated: true, npc: npcName, disposition: newDisposition };
+}
+
+async function executeTool(plotId, toolName, args) {
+    switch (toolName) {
+        case 'get_scene': return await executeGetScene(plotId);
+        case 'lookup_npc': return await executeLookupNpc(plotId, args.name);
+        case 'move_player': return await executeMovePlayer(plotId, args.destination);
+        case 'update_npc_relationship': return await executeUpdateRelationship(plotId, args.npc_name, args.new_disposition, args.reason);
+        default: return { error: `Unknown tool: ${toolName}` };
+    }
+}
+
+// ============ DISPLAY HELPERS ============
+
+function getToolDisplay(toolName, args) {
+    switch (toolName) {
+        case 'get_scene': return 'Observing the scene...';
+        case 'lookup_npc': return `Recalling ${args.name || 'character'}...`;
+        case 'move_player': return `Moving to ${args.destination || 'location'}...`;
+        case 'update_npc_relationship': return `Noting reaction from ${args.npc_name || 'NPC'}...`;
+        default: return 'Thinking...';
+    }
+}
+
+function formatToolResult(toolName, result) {
+    switch (toolName) {
+        case 'get_scene':
+            let scene = `CURRENT SCENE: ${result.location}${result.locationType ? ' (' + result.locationType + ')' : ''} in ${result.settlement || 'the wilds'}`;
+            scene += `\n${result.description}`;
+            scene += `\nTime: ${result.timeOfDay}`;
+            if (result.exits?.length > 0) {
+                scene += `\nEXITS: ${result.exits.map(e => `${e.direction}: ${e.name}${e.via ? ' — ' + e.via : ''}`).join('; ')}`;
+            }
+            if (result.npcsPresent?.length > 0) {
+                scene += `\nPEOPLE HERE: ${result.npcsPresent.map(n => `${n.name}${n.description ? ' — ' + n.description : ''}`).join('; ')}`;
+            }
+            if (result.objects?.length > 0) {
+                scene += `\nNOTABLE OBJECTS: ${result.objects.map(o => `${o.name} (${o.type})`).join('; ')}`;
+            }
+            return scene;
+
+        case 'lookup_npc':
+            if (!result.found) return `NPC "${result.name}": Not previously encountered. This is a new character.`;
+            let npc = `NPC: ${result.name}`;
+            npc += `\nAttitude toward player: ${result.disposition}`;
+            npc += `\nLast interaction: ${result.lastInteraction}`;
+            if (result.description) npc += `\nDescription: ${result.description}`;
+            if (result.interactionCount > 0) npc += `\nTimes spoken to: ${result.interactionCount}`;
+            return npc;
+
+        case 'move_player':
+            if (!result.success) return `MOVEMENT BLOCKED: ${result.reason}`;
+            return `MOVED TO: ${result.newLocation}\n${result.narration}`;
+
+        case 'update_npc_relationship':
+            return `RELATIONSHIP UPDATED: ${result.npc} is now ${result.disposition}`;
+
+        default:
+            return JSON.stringify(result);
+    }
+}
+
+// ============ GET RECENT MESSAGES (direct DB query) ============
+
+async function getRecentMessages(plotId, limit = 10) {
+    const logs = await GameLog.find({ plotId })
+        .sort({ _id: -1 })
+        .limit(3);
+
+    if (!logs.length) return [];
+
+    const allMessages = [];
+    for (const log of logs) {
+        for (const msg of log.messages) {
+            allMessages.push(msg);
+        }
+    }
+
+    // Sort by timestamp descending, take the most recent
+    allMessages.sort((a, b) => b.timestamp - a.timestamp);
+    const recent = allMessages.slice(0, limit).reverse();
+    return recent;
+}
+
+// ============ MAIN AGENT FLOW ============
+
+/**
+ * Process player input through the agent pipeline.
+ * Yields events: { type: 'tool_call' | 'chunk' | 'done', ... }
+ */
+async function* processInput(input, plotId, cookies) {
+    const startTime = Date.now();
+
+    // Load plot
+    const plot = await Plot.findById(plotId)
+        .populate('current_state.current_location.region')
+        .populate('current_state.current_location.settlement');
+
+    if (!plot) {
+        yield { type: 'chunk', content: 'Error: Game not found.' };
+        yield { type: 'done' };
+        return;
+    }
+
+    // Ensure descriptions exist
+    if (plot.current_state?.current_location?.region?._id) {
+        const Region = require('../db/models/Region');
+        const regionFactory = require('../agents/world/factories/regionsFactory');
+        const settlementsFactory = require('../agents/world/factories/settlementsFactory');
+        const region = await Region.findById(plot.current_state.current_location.region._id);
+        const settlementId = plot.current_state.current_location.settlement?._id;
+
+        if (!region.described) {
+            yield { type: 'tool_call', tool: 'system', display: 'Discovering new lands...' };
+            await regionFactory.describe(region._id);
+        }
+        if (settlementId) {
+            const settlement = await Settlement.findById(settlementId);
+            if (!settlement.described) {
+                await regionFactory.describeSettlements(region._id);
+            }
+            if (settlement.described && !settlement.locationsGenerated) {
+                await settlementsFactory.ensureLocations(settlementId);
+            }
+        }
+    }
+
+    // Get conversation history
+    const recentMessages = await getRecentMessages(plotId, 10);
+    const historyContext = recentMessages.length > 0
+        ? recentMessages.map(msg => `${msg.author}: ${msg.content}`).join('\n')
+        : 'This is the start of the adventure.';
+
+    const locationName = plot.current_state?.current_location?.settlement?.name || 'Unknown';
+    const currentLocName = plot.current_state?.current_location?.locationName || '';
+    const tone = plot.settings?.tone || 'classic';
+    const difficulty = plot.settings?.difficulty || 'casual';
+
+    console.log(`[GameAgent] Planning phase... (${Date.now() - startTime}ms)`);
+
+    // ---- STEP 1: Planning call ----
+    const planMessages = [
+        {
+            role: "system",
+            content: `You are a game world AI deciding how to handle a player's action. Pick the tools you need.
+
+RULES:
+- Call get_scene to understand the player's surroundings (usually always useful)
+- Call lookup_npc when the player talks to or asks about a NAMED character
+- Call move_player ONLY for explicit movement to a different named location
+- Call update_npc_relationship ONLY after a significant attitude-changing interaction
+- You can call multiple tools
+- For simple actions in the current location, get_scene alone is enough
+
+CONTEXT: Player is at ${currentLocName || locationName}. Time: ${plot.current_state?.current_time || 'day'}.
+
+RECENT CONVERSATION:
+${historyContext}`
+        },
+        { role: "user", content: input }
+    ];
+
+    let toolCalls = [];
+    try {
+        const planResponse = await openai.chat.completions.create({
+            model: GAME_MODEL,
+            messages: planMessages,
+            tools: TOOLS,
+            tool_choice: "auto"
+        });
+
+        const msg = planResponse.choices[0].message;
+        if (msg.tool_calls?.length > 0) {
+            toolCalls = msg.tool_calls;
+        }
+    } catch (error) {
+        console.error('[GameAgent] Planning failed:', error.message);
+    }
+
+    // Default: always get scene if no tools selected
+    if (toolCalls.length === 0) {
+        toolCalls = [{
+            id: 'default_scene',
+            type: 'function',
+            function: { name: 'get_scene', arguments: '{}' }
+        }];
+    }
+
+    console.log(`[GameAgent] Tools selected: ${toolCalls.map(t => t.function.name).join(', ')} (${Date.now() - startTime}ms)`);
+
+    // ---- STEP 2: Execute tools ----
+    const toolResultTexts = [];
+    let movementNarration = null;
+
+    for (const tc of toolCalls) {
+        const toolName = tc.function.name;
+        const args = JSON.parse(tc.function.arguments || '{}');
+
+        // Emit tool call event for frontend
+        yield { type: 'tool_call', tool: toolName, display: getToolDisplay(toolName, args) };
+
+        const result = await executeTool(plotId, toolName, args);
+        toolResultTexts.push(formatToolResult(toolName, result));
+
+        // If movement happened, capture the narration
+        if (toolName === 'move_player' && result.success) {
+            movementNarration = result.narration;
+        }
+    }
+
+    console.log(`[GameAgent] Tools executed (${Date.now() - startTime}ms)`);
+
+    // ---- STEP 3: Stream narrative ----
+    const enrichedContext = toolResultTexts.join('\n\n');
+
+    const narrativeSystemPrompt = `${buildSystemPrompt(tone, difficulty)}
+
+RESPONSE RULES (CRITICAL):
+- Respond DIRECTLY to what the player just said or did. First sentence = immediate reaction.
+- Do NOT re-describe the scene or location. The player is already there.
+- If the player is talking to someone, that person responds. Do NOT introduce random other characters.
+- Keep conversation continuity — if a conversation is in progress, continue it naturally.
+- Be CONCISE. 2-3 sentences for most responses.
+- Focus ONLY on what is NEW — the direct result of this specific input.
+- Never narrate the player's thoughts or feelings.
+- If the player both acts AND speaks (e.g. "I sit down and say hello"), handle both naturally in one response.`;
+
+    const narrativeMessages = [
+        { role: "system", content: narrativeSystemPrompt },
+        {
+            role: "user",
+            content: `GAME STATE:\n${enrichedContext}\n\nRECENT CONVERSATION:\n${historyContext}\n\nPLAYER: "${input}"\n\nRespond to the player's action/words. Be direct and concise.`
+        }
+    ];
+
+    try {
+        const stream = await openai.chat.completions.create({
+            model: GAME_MODEL,
+            messages: narrativeMessages,
+            stream: true
+        });
+
+        let fullResponse = '';
+
+        // If movement happened, yield that narration first
+        if (movementNarration) {
+            yield { type: 'chunk', content: movementNarration + '\n\n' };
+            fullResponse += movementNarration + '\n\n';
+        }
+
+        for await (const chunk of stream) {
+            const content = chunk.choices[0]?.delta?.content;
+            if (content) {
+                fullResponse += content;
+                yield { type: 'chunk', content };
+            }
+        }
+
+        // Post-processing: state updates
+        const lowerInput = input.toLowerCase();
+        if (lowerInput.includes('rest') || lowerInput.includes('sleep')) {
+            plot.current_state.current_activity = 'resting';
+            if (lowerInput.includes('until morning')) plot.current_state.current_time = 'morning';
+        } else if (lowerInput.includes('attack') || lowerInput.includes('fight')) {
+            plot.current_state.current_activity = 'in combat';
+        } else if (plot.current_state.current_activity === 'resting') {
+            plot.current_state.current_activity = 'exploring';
+        }
+        await plot.save();
+
+        // Async discovery parsing
+        try {
+            const discoveryService = require('./discoveryService');
+            if (discoveryService.likelyHasDiscoveries(fullResponse)) {
+                discoveryService.parseDiscoveries(plotId, fullResponse, input)
+                    .catch(err => console.error('[Discovery] Background parse failed:', err));
+            }
+        } catch (e) { /* non-critical */ }
+
+        console.log(`[GameAgent] Narrative complete (${Date.now() - startTime}ms)`);
+
+        // Generate suggested next actions (non-blocking)
+        try {
+            console.log(`[GameAgent] Generating suggestions...`);
+            const suggestionResponse = await openai.chat.completions.create({
+                model: GAME_MODEL,
+                messages: [
+                    {
+                        role: "system",
+                        content: `You suggest player actions for an RPG. Return ONLY valid JSON, no other text.
+Format: {"actions": [{"label": "Short Label", "action": "I do something specific"}, ...]}
+Rules:
+- Exactly 3 actions
+- Labels: 2-4 words (button text)
+- Actions: first-person "I ..." sentences
+- Contextually relevant and varied
+- Never suggest looking around or resting`
+                    },
+                    {
+                        role: "user",
+                        content: `SCENE:\n${enrichedContext}\n\nPLAYER DID: "${input}"\n\nAI RESPONDED: "${fullResponse}"\n\nSuggest 3 actions. Return ONLY JSON.`
+                    }
+                ]
+            });
+
+            const suggestionsText = suggestionResponse.choices[0]?.message?.content;
+            console.log(`[GameAgent] Suggestion raw response:`, suggestionsText);
+            if (suggestionsText) {
+                // Extract JSON from response (handle markdown code blocks)
+                let jsonStr = suggestionsText.trim();
+                const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+                if (jsonMatch) jsonStr = jsonMatch[1].trim();
+
+                const parsed = JSON.parse(jsonStr);
+                if (parsed.actions && Array.isArray(parsed.actions) && parsed.actions.length > 0) {
+                    const actions = parsed.actions.slice(0, 3);
+                    console.log(`[GameAgent] Suggestions generated:`, actions);
+                    yield { type: 'suggested_actions', actions };
+                    console.log(`[GameAgent] Suggestions yielded (${Date.now() - startTime}ms)`);
+                }
+            }
+        } catch (suggestError) {
+            console.error('[GameAgent] Suggestion generation failed (non-critical):', suggestError.message);
+        }
+
+    } catch (error) {
+        console.error('[GameAgent] Narrative streaming failed:', error.message);
+        yield { type: 'chunk', content: 'The world falls silent for a moment...' };
+    }
+
+    yield { type: 'done' };
+}
+
+module.exports = { processInput, TOOLS };

--- a/services/layoutService.js
+++ b/services/layoutService.js
@@ -1,0 +1,354 @@
+/**
+ * layoutService.js - Computes spatial layout positions for settlement locations
+ *
+ * Uses BFS from the starting location to assign (x, y) coordinates based on
+ * compass directions and distances from the connection graph.
+ * Pure computation — no DB side effects.
+ */
+
+const DIRECTION_VECTORS = {
+    north:     { x: 0,    y: -1 },
+    south:     { x: 0,    y: 1 },
+    east:      { x: 1,    y: 0 },
+    west:      { x: -1,   y: 0 },
+    northeast: { x: 0.7,  y: -0.7 },
+    northwest: { x: -0.7, y: -0.7 },
+    southeast: { x: 0.7,  y: 0.7 },
+    southwest: { x: -0.7, y: 0.7 },
+    up:        { x: 0.3,  y: -0.5 },
+    down:      { x: -0.3, y: 0.5 },
+    inside:    { x: 0.3,  y: 0 },
+    outside:   { x: -0.3, y: 0 }
+};
+
+const DISTANCE_SCALE = {
+    adjacent: 1,
+    close: 1.5,
+    far: 2
+};
+
+/**
+ * Check if a position collides with any existing placed position
+ */
+function hasCollision(x, y, placedPositions, threshold = 0.5) {
+    for (const pos of placedPositions.values()) {
+        const dx = pos.x - x;
+        const dy = pos.y - y;
+        if (Math.sqrt(dx * dx + dy * dy) < threshold) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Nudge a position outward to avoid collision (spiral search, up to 8 directions)
+ */
+function nudgePosition(x, y, placedPositions) {
+    const nudgeAngles = [0, 45, 90, 135, 180, 225, 270, 315];
+    const nudgeDistance = 0.6;
+
+    for (let ring = 1; ring <= 3; ring++) {
+        for (const angle of nudgeAngles) {
+            const rad = (angle * Math.PI) / 180;
+            const nx = x + Math.cos(rad) * nudgeDistance * ring;
+            const ny = y + Math.sin(rad) * nudgeDistance * ring;
+            if (!hasCollision(nx, ny, placedPositions)) {
+                return { x: nx, y: ny };
+            }
+        }
+    }
+
+    // Fallback: just offset significantly
+    return { x: x + 1.5, y: y + 0.5 };
+}
+
+/**
+ * Detect and fix degenerate linear layouts.
+ * If all points are roughly collinear (spread in one axis but flat in the other),
+ * redistribute them into a more natural cluster using a golden-angle spiral.
+ */
+function fixLinearLayout(positions) {
+    if (positions.size < 3) return;
+
+    const pts = Array.from(positions.values());
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const p of pts) {
+        if (p.x < minX) minX = p.x;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.y > maxY) maxY = p.y;
+    }
+
+    const rangeX = maxX - minX;
+    const rangeY = maxY - minY;
+    const ratio = Math.min(rangeX, rangeY) / (Math.max(rangeX, rangeY) || 1);
+
+    // If the smaller axis is less than 15% of the larger, it's too linear
+    if (ratio >= 0.15) return;
+
+    // Redistribute using golden-angle spiral around centroid
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    const goldenAngle = Math.PI * (3 - Math.sqrt(5)); // ~137.5 degrees
+    const spacing = 1.0;
+    let i = 0;
+
+    for (const [key, pos] of positions) {
+        if (i === 0) {
+            // First node (start) stays at center
+            pos.x = cx;
+            pos.y = cy;
+        } else {
+            const r = spacing * Math.sqrt(i);
+            const theta = i * goldenAngle;
+            pos.x = cx + r * Math.cos(theta);
+            pos.y = cy + r * Math.sin(theta);
+        }
+        i++;
+    }
+}
+
+/**
+ * Compute layout positions for all locations in a settlement using BFS.
+ *
+ * @param {Array} locations - Array of location objects (with name, connections, isStartingLocation)
+ * @returns {Map<string, {x: number, y: number}>} Map of lowercase name → position
+ */
+function computeLayout(locations) {
+    if (!locations || locations.length === 0) {
+        return new Map();
+    }
+
+    const positions = new Map(); // key: name.toLowerCase() → {x, y}
+
+    // Build lookup by lowercase name
+    const byName = new Map();
+    for (const loc of locations) {
+        byName.set(loc.name.toLowerCase(), loc);
+    }
+
+    // Find starting node: isStartingLocation → first gate → first location
+    let startLoc = locations.find(l => l.isStartingLocation)
+        || locations.find(l => l.type === 'gate')
+        || locations[0];
+
+    const startKey = startLoc.name.toLowerCase();
+    positions.set(startKey, { x: 0, y: 0 });
+
+    // BFS
+    const queue = [startKey];
+    const visited = new Set([startKey]);
+
+    while (queue.length > 0) {
+        const currentKey = queue.shift();
+        const currentLoc = byName.get(currentKey);
+        if (!currentLoc) continue;
+
+        const currentPos = positions.get(currentKey);
+        const connections = currentLoc.connections || [];
+
+        for (const conn of connections) {
+            if (!conn.locationName) continue;
+            const targetKey = conn.locationName.toLowerCase();
+
+            if (visited.has(targetKey)) continue;
+            visited.add(targetKey);
+
+            // Compute position from direction + distance
+            const dir = DIRECTION_VECTORS[conn.direction] || { x: 0.5, y: 0.5 };
+            const scale = DISTANCE_SCALE[conn.distance] || 1;
+
+            let newX = currentPos.x + dir.x * scale;
+            let newY = currentPos.y + dir.y * scale;
+
+            // Collision check and nudge
+            if (hasCollision(newX, newY, positions)) {
+                const nudged = nudgePosition(newX, newY, positions);
+                newX = nudged.x;
+                newY = nudged.y;
+            }
+
+            positions.set(targetKey, { x: newX, y: newY });
+
+            // Only enqueue if this location exists in our location list
+            if (byName.has(targetKey)) {
+                queue.push(targetKey);
+            }
+        }
+    }
+
+    // Detect and fix degenerate linear layouts
+    if (positions.size >= 3) {
+        fixLinearLayout(positions);
+    }
+
+    // Handle disconnected/unplaced locations: row below main cluster
+    let maxY = 0;
+    for (const pos of positions.values()) {
+        if (pos.y > maxY) maxY = pos.y;
+    }
+
+    let orphanX = 0;
+    for (const loc of locations) {
+        const key = loc.name.toLowerCase();
+        if (!positions.has(key)) {
+            positions.set(key, { x: orphanX, y: maxY + 2 });
+            orphanX += 1.2;
+        }
+    }
+
+    return positions;
+}
+
+/**
+ * Compute position for a single new location being added to an existing settlement.
+ *
+ * @param {Array} existingLocations - Already-placed locations (with coordinates)
+ * @param {Object} newLocation - The new location object (with connections)
+ * @returns {{x: number, y: number}} Computed position
+ */
+function computeSingleNodePosition(existingLocations, newLocation) {
+    if (!existingLocations || existingLocations.length === 0) {
+        return { x: 0, y: 0 };
+    }
+
+    // Build map of existing positions
+    const placedPositions = new Map();
+    for (const loc of existingLocations) {
+        if (loc.coordinates) {
+            placedPositions.set(loc.name.toLowerCase(), {
+                x: loc.coordinates.x || 0,
+                y: loc.coordinates.y || 0
+            });
+        }
+    }
+
+    // Try to position based on connections to existing locations
+    const connections = newLocation.connections || [];
+    for (const conn of connections) {
+        if (!conn.locationName) continue;
+        const sourceKey = conn.locationName.toLowerCase();
+        const sourcePos = placedPositions.get(sourceKey);
+        if (!sourcePos) continue;
+
+        // Reverse the direction (if new connects to existing via "north",
+        // new is south of existing, but the connection says the existing is "north" of new,
+        // so new should be placed south of existing)
+        // Actually: the connection says "from newLocation, go <direction> to reach conn.locationName"
+        // So the new location is the OPPOSITE direction from the existing.
+        // We want to place newLocation, and the connection says "to get from newLocation to source, go <dir>"
+        // So newLocation is at source - dirVector
+        const dir = DIRECTION_VECTORS[conn.direction] || { x: 0.5, y: 0.5 };
+        const scale = DISTANCE_SCALE[conn.distance] || 1;
+
+        let newX = sourcePos.x - dir.x * scale;
+        let newY = sourcePos.y - dir.y * scale;
+
+        if (hasCollision(newX, newY, placedPositions)) {
+            const nudged = nudgePosition(newX, newY, placedPositions);
+            newX = nudged.x;
+            newY = nudged.y;
+        }
+
+        return { x: newX, y: newY };
+    }
+
+    // Also check if any existing location connects TO this new location
+    for (const loc of existingLocations) {
+        const locConns = loc.connections || [];
+        for (const conn of locConns) {
+            if (conn.locationName?.toLowerCase() === newLocation.name.toLowerCase()) {
+                const sourcePos = placedPositions.get(loc.name.toLowerCase());
+                if (!sourcePos) continue;
+
+                const dir = DIRECTION_VECTORS[conn.direction] || { x: 0.5, y: 0.5 };
+                const scale = DISTANCE_SCALE[conn.distance] || 1;
+
+                let newX = sourcePos.x + dir.x * scale;
+                let newY = sourcePos.y + dir.y * scale;
+
+                if (hasCollision(newX, newY, placedPositions)) {
+                    const nudged = nudgePosition(newX, newY, placedPositions);
+                    newX = nudged.x;
+                    newY = nudged.y;
+                }
+
+                return { x: newX, y: newY };
+            }
+        }
+    }
+
+    // Fallback: place below the cluster
+    let maxY = 0;
+    for (const pos of placedPositions.values()) {
+        if (pos.y > maxY) maxY = pos.y;
+    }
+    return { x: 0, y: maxY + 2 };
+}
+
+const VALID_DIRECTIONS = new Set(Object.keys(DIRECTION_VECTORS));
+
+/**
+ * Normalize an AI-generated direction string to a valid schema enum value.
+ * Handles common AI mistakes: hyphens ("north-east"), extra words ("southeast (ice-bridge)"),
+ * descriptive phrases ("up the cliff"), and near-matches ("nearby").
+ *
+ * @param {string} raw - The raw direction string from the AI
+ * @returns {string|null} A valid direction enum value, or null if unrecognizable
+ */
+function normalizeDirection(raw) {
+    if (!raw) return null;
+
+    // Strip to lowercase, trim whitespace
+    let d = raw.toLowerCase().trim();
+
+    // Exact match
+    if (VALID_DIRECTIONS.has(d)) return d;
+
+    // Remove parenthetical descriptions: "southeast (ice-bridge)" → "southeast"
+    d = d.replace(/\s*\(.*\)/, '').trim();
+    if (VALID_DIRECTIONS.has(d)) return d;
+
+    // Remove "via ...", "the ...", "to ..." suffixes: "northeast via the rope-bridge" → "northeast"
+    d = d.replace(/\s+(via|the|to|from|through|along|across|over)\b.*$/, '').trim();
+    if (VALID_DIRECTIONS.has(d)) return d;
+
+    // Remove hyphens: "north-east" → "northeast", "south-west" → "southwest"
+    const dehyphenated = d.replace(/-/g, '');
+    if (VALID_DIRECTIONS.has(dehyphenated)) return dehyphenated;
+
+    // Extract leading direction word from descriptive phrases:
+    // "up the cliff-face" → "up", "down the glaciar-steps" → "down"
+    const leadingMatch = d.match(/^(north|south|east|west|northeast|northwest|southeast|southwest|up|down|inside|outside)\b/);
+    if (leadingMatch) return leadingMatch[1];
+
+    // Compound with space: "north east" → "northeast"
+    const compoundMatch = d.match(/^(north|south)\s*(east|west)$/);
+    if (compoundMatch) return compoundMatch[1] + compoundMatch[2];
+
+    // "nearby" or other unrecognizable → pick a random valid direction
+    return null;
+}
+
+/**
+ * Sanitize a direction, returning a valid enum value.
+ * Falls back to a random cardinal direction if normalization fails.
+ */
+function sanitizeDirection(raw) {
+    const normalized = normalizeDirection(raw);
+    if (normalized) return normalized;
+
+    // Fallback: pick a random cardinal direction
+    const fallbacks = ['north', 'south', 'east', 'west', 'northeast', 'northwest', 'southeast', 'southwest'];
+    return fallbacks[Math.floor(Math.random() * fallbacks.length)];
+}
+
+module.exports = {
+    computeLayout,
+    computeSingleNodePosition,
+    normalizeDirection,
+    sanitizeDirection,
+    DIRECTION_VECTORS,
+    DISTANCE_SCALE
+};


### PR DESCRIPTION
## Summary
- **Region selection screen**: after choosing a world, players now see all regions as cards with ecosystem tags and GPT-generated adventure hooks (loaded async so cards appear instantly)
- **Instant plot creation**:  no longer makes GPT calls — creates plot with  and returns in ~100ms
- **Deferred initialization via SSE**: new  streams progress events while describing the starting region/settlement and generating locations. Only the starting settlement is described upfront; remaining settlements are described in the background after the player starts playing
- **Init overlay on game page**: full-screen overlay with progress bar, breathing dragon animation, and retry button. Handles created/initializing/ready/error states with cache-busted polling and 2-minute timeout guard
- **Auto-redirect**: after character creation, players are redirected straight to the game page instead of back to the character list
- **Prior work included**: SVG settlement map with fog of war, BFS layout algorithm, game agent with tool-use streaming, movement/discovery service improvements

## Test plan
- [ ] Create new game in existing world — see region selection with adventure hooks
- [ ] Pick a region — character creator opens instantly
- [ ] Create character — auto-redirect to game page
- [ ] Init overlay shows progress (~60s) — fades to reveal playable game
- [ ] Existing games load normally (no overlay)
- [ ] Refresh during initialization — polling recovers and completes
- [ ] Verify quests appear in modal after background generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)