### PR TITLE
Add organic, player-driven quest system

### DIFF
--- a/db/models/GameLog.js
+++ b/db/models/GameLog.js
@@ -35,7 +35,12 @@ const MessageSchema = new Schema({
         minPass: Number,
         strongPass: Number,
         result: String
-    }
+    },
+    questUpdates: [{
+        questId: String,
+        title: String,
+        status: String
+    }]
 });
 
 const GameLogSchema = new Schema({

--- a/db/models/Plot.js
+++ b/db/models/Plot.js
@@ -125,6 +125,11 @@ const Plot = new Schema(
             mood_tone: {
                 type: String, // e.g., "tense", "relaxed"
             },
+            questState: {
+                lastSeedGeneration: { type: Date },
+                seedSettlement: { type: mongoose.Schema.Types.ObjectId, ref: 'Settlement' },
+                turnsSinceLastHook: { type: Number, default: 0 }
+            },
             sceneContext: {
                 summary: { type: String, default: '' },
                 tension: {
@@ -163,7 +168,9 @@ const Plot = new Schema(
                     type: String,
                 },
                 questStatus: {
-                    type: String
+                    type: String,
+                    enum: ['seed', 'discovered', 'active', 'completed', 'failed', 'expired'],
+                    default: 'seed'
                 },
                 notes: {
                     type: Array

--- a/db/models/Quest.js
+++ b/db/models/Quest.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+
 const Quest = new Schema(
     {
         world: {
@@ -7,29 +8,48 @@ const Quest = new Schema(
             ref: 'World',
             required: true
         },
+        settlement: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Settlement'
+        },
         questTitle: {
             type: String,
         },
         description: {
             type: String
         },
-        objectives: {
-            type: Array
-        },
-        currentObjective: {
-            type: String
-        },
         status: {
             type: String,
-            enum: ['Not started', 'Active - In progress', 'Not Active - In progress', 'Completed'],
-            default: 'Not started',
+            enum: ['seed', 'discovered', 'active', 'completed', 'failed', 'expired'],
+            default: 'seed',
         },
-        triggers: {
-            conditions: [
-                {
-                    type: String
-                }
-            ]
+        objectives: [{
+            id: { type: String },
+            description: { type: String },
+            status: {
+                type: String,
+                enum: ['unknown', 'known', 'in_progress', 'completed', 'failed'],
+                default: 'unknown'
+            },
+            isCurrent: { type: Boolean, default: false }
+        }],
+        hooks: [{
+            text: { type: String },
+            type: {
+                type: String,
+                enum: ['rumor', 'observation', 'npc_mention', 'environmental'],
+                default: 'rumor'
+            },
+            delivered: { type: Boolean, default: false },
+            deliveredAt: { type: Date }
+        }],
+        progression: [{
+            summary: { type: String },
+            timestamp: { type: Date, default: Date.now }
+        }],
+        currentSummary: {
+            type: String,
+            default: ''
         },
         keyActors: {
             primary: [
@@ -71,7 +91,8 @@ const Quest = new Schema(
             immediate: { type: String },
             longTerm: { type: String }
         }
-    }
+    },
+    { timestamps: true }
 );
 
 module.exports = mongoose.model('Quest', Quest);

--- a/public/index.html
+++ b/public/index.html
@@ -107,7 +107,7 @@
         <!-- Game Buttons -->
         <div id="game-buttons">
             <button id="start-game-btn">▶️ Start</button>
-            <button id="view-quests-btn">📜 Quests</button>
+            <button id="view-quests-btn">📜 Journal</button>
             <button id="reputation-btn">🤝 Rep</button>
             <button id="story-summary-btn">📖 Story</button>
             <button id="settings-btn">⚙️</button>
@@ -143,13 +143,24 @@
     </div>
 </div>
 
-<!-- Quests Modal -->
+<!-- Quest Journal Modal -->
 <div id="quests-modal" class="modal" style="display: none;">
-    <div class="modal-content">
+    <div class="modal-content quest-journal">
         <span class="close" id="close-quests-modal">&times;</span>
-        <h3>📜 Quests</h3>
-        <div id="quests-table-container">
-            <!-- Quests table will be populated here -->
+        <h3>Quest Journal</h3>
+        <div id="quest-journal-content">
+            <div class="qj-section" id="qj-active">
+                <h4>Active Quests</h4>
+                <div class="qj-list" id="qj-active-list"></div>
+            </div>
+            <div class="qj-section" id="qj-leads">
+                <h4>Leads</h4>
+                <div class="qj-list" id="qj-leads-list"></div>
+            </div>
+            <div class="qj-section" id="qj-completed">
+                <h4>Completed</h4>
+                <div class="qj-list" id="qj-completed-list"></div>
+            </div>
         </div>
     </div>
 </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2116,3 +2116,173 @@ body {
   }
 }
 
+/* ============================================
+   QUEST JOURNAL
+   ============================================ */
+
+.quest-journal {
+  max-width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.qj-section {
+  margin-bottom: 20px;
+}
+
+.qj-section h4 {
+  color: var(--accent-gold);
+  font-family: 'Crimson Text', serif;
+  font-size: 1.1rem;
+  margin-bottom: 8px;
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+  padding-bottom: 4px;
+}
+
+.qj-card {
+  background: var(--bg-input);
+  border-left: 3px solid #888;
+  border-radius: 6px;
+  padding: 12px;
+  margin-bottom: 8px;
+}
+
+.qj-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.qj-title {
+  font-family: 'Crimson Text', serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.qj-badge {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 10px;
+  color: white;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.qj-description {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+}
+
+.qj-summary {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-bottom: 6px;
+}
+
+.qj-objectives {
+  margin-top: 6px;
+}
+
+.qj-objective {
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  padding: 2px 0;
+}
+
+.qj-obj-current {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.qj-track-btn {
+  margin-top: 8px;
+  background: var(--accent-indigo);
+  color: white;
+  border: none;
+  padding: 6px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  transition: background 0.2s;
+}
+
+.qj-track-btn:hover {
+  background: #4f46e5;
+}
+
+/* ============================================
+   QUEST DISCOVERY CARD (inline in game log)
+   ============================================ */
+
+.quest-discovery-card {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.12), rgba(245, 158, 11, 0.04));
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 10px 0;
+  animation: qdc-appear 0.5s ease;
+}
+
+@keyframes qdc-appear {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.qdc-header {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #f59e0b;
+  margin-bottom: 4px;
+}
+
+.qdc-title {
+  font-family: 'Crimson Text', serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.qdc-description {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.qdc-track-btn {
+  background: #f59e0b;
+  color: #1a1a2e;
+  border: none;
+  padding: 5px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: background 0.2s;
+}
+
+.qdc-track-btn:hover {
+  background: #d97706;
+}
+
+.qdc-track-btn:disabled,
+.qdc-tracked {
+  background: #22c55e;
+  cursor: default;
+  color: white;
+}
+
+/* Quest button pulse notification */
+@keyframes quest-pulse {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: 0 0 12px rgba(245, 158, 11, 0.6); }
+}
+
+.quest-notify {
+  animation: quest-pulse 0.5s ease 3;
+}
+

--- a/routes/gameLogs.js
+++ b/routes/gameLogs.js
@@ -72,7 +72,7 @@ router.get('/game-logs/:gameLogId/:plotId', ensureAuthenticated, async (req, res
 // Create or update a game log entry
 router.post('/game-logs', ensureAuthenticated, async (req, res) => {
     try {
-        const { plotId, author, content, sceneEntities, discoveries, skillCheck } = req.body;
+        const { plotId, author, content, sceneEntities, discoveries, skillCheck, questUpdates } = req.body;
         const plot = await Plot.findById(plotId).populate('gameLogs');
         if (!plot) return res.status(404).send('Plot not found');
 
@@ -98,6 +98,7 @@ router.post('/game-logs', ensureAuthenticated, async (req, res) => {
         if (sceneEntities) message.sceneEntities = sceneEntities;
         if (discoveries && discoveries.length > 0) message.discoveries = discoveries;
         if (skillCheck) message.skillCheck = skillCheck;
+        if (questUpdates && questUpdates.length > 0) message.questUpdates = questUpdates;
         gameLog.messages.push(message);
         await gameLog.save();
 
@@ -157,6 +158,12 @@ router.post('/input/stream', ensureAuthenticated, async (req, res) => {
                         break;
                     case 'scene_context':
                         res.write(`data: ${JSON.stringify({ scene_context: event.context })}\n\n`);
+                        break;
+                    case 'quest_discovered':
+                        res.write(`data: ${JSON.stringify({ quest_discovered: event.quests })}\n\n`);
+                        break;
+                    case 'quest_update':
+                        res.write(`data: ${JSON.stringify({ quest_update: event.data })}\n\n`);
                         break;
                     case 'done':
                         // handled below

--- a/services/questService.js
+++ b/services/questService.js
@@ -1,0 +1,603 @@
+/**
+ * Quest Service — Organic, player-driven quest system
+ *
+ * Quests emerge from player behavior:
+ *   seed → discovered → active → completed/failed/expired
+ *
+ * Seeds are generated in the background based on probability.
+ * Hooks are woven into narration. Discovery happens when the AI mentions quest elements.
+ * Activation is player-initiated ("Track Quest" button).
+ */
+
+const Plot = require('../db/models/Plot');
+const Quest = require('../db/models/Quest');
+const GameLog = require('../db/models/GameLog');
+const { simplePrompt } = require('./gptService');
+
+// ============ SEED GENERATION ============
+
+/**
+ * Determine whether to generate new quest seeds this turn.
+ * Returns true with a probability based on game state.
+ */
+async function shouldGenerateSeeds(plotId) {
+    try {
+        const plot = await Plot.findById(plotId);
+        if (!plot) return false;
+
+        // Hard skip: combat
+        if (plot.current_state?.current_activity === 'in combat') return false;
+
+        const qs = plot.current_state?.questState || {};
+        const settlementId = plot.current_state?.current_location?.settlement;
+        if (!settlementId) return false;
+
+        // Count existing quests
+        const seedsAtSettlement = await Quest.countDocuments({
+            world: plot.world,
+            settlement: settlementId,
+            status: 'seed'
+        });
+        const activeQuests = await Quest.countDocuments({
+            world: plot.world,
+            status: 'active'
+        });
+
+        // Calculate turns since last seed generation
+        const turnCount = plot.current_state?.sceneContext?.turnCount || 0;
+        const lastSeedTurn = qs.lastSeedGeneration
+            ? Math.max(0, turnCount - 3) // approximate
+            : turnCount; // never generated = max boost
+
+        // Base chance: 15%
+        let probability = 0.15;
+
+        // Boosters
+        probability += Math.min(0.50, lastSeedTurn * 0.10); // +10% per turn since last, cap +50%
+        if (activeQuests === 0) probability += 0.15;
+
+        // Check if player just moved (turnCount === 0 or 1 means fresh location)
+        if (turnCount <= 1) probability += 0.10;
+
+        // Dampeners
+        probability -= seedsAtSettlement * 0.10;
+        probability -= activeQuests * 0.15;
+        if (qs.lastSeedGeneration) {
+            const msSinceLast = Date.now() - new Date(qs.lastSeedGeneration).getTime();
+            if (msSinceLast < 60000) probability -= 0.20; // < 1 min ago (roughly 3 turns)
+        }
+
+        // Clamp
+        probability = Math.max(0.05, Math.min(0.85, probability));
+
+        const roll = Math.random();
+        console.log(`[Quest] shouldGenerateSeeds: prob=${(probability * 100).toFixed(0)}%, roll=${(roll * 100).toFixed(0)}%, seeds@settlement=${seedsAtSettlement}, active=${activeQuests}`);
+        return roll < probability;
+    } catch (e) {
+        console.error('[Quest] shouldGenerateSeeds error:', e.message);
+        return false;
+    }
+}
+
+/**
+ * Generate 1-2 quest seeds via GPT, save to DB, link to Plot.
+ */
+async function generateQuestSeeds(plotId) {
+    const plot = await Plot.findById(plotId)
+        .populate('current_state.current_location.region')
+        .populate('current_state.current_location.settlement');
+
+    if (!plot) return [];
+
+    const settlement = plot.current_state?.current_location?.settlement;
+    const region = plot.current_state?.current_location?.region;
+    if (!settlement) return [];
+
+    // Get recent messages for context
+    const logs = await GameLog.find({ plotId }).sort({ _id: -1 }).limit(2);
+    const recentMessages = [];
+    for (const log of logs) {
+        for (const msg of log.messages) {
+            recentMessages.push(`${msg.author}: ${msg.content.substring(0, 200)}`);
+        }
+    }
+    const recentContext = recentMessages.slice(-10).join('\n');
+
+    // Get existing quest titles to avoid duplicates
+    const existingQuests = await Quest.find({ world: plot.world }).select('questTitle');
+    const existingTitles = existingQuests.map(q => q.questTitle).filter(Boolean);
+
+    const prompt = `You are creating quest seeds for an RPG with an "Indifferent World" philosophy — the world doesn't revolve around the player. Quests emerge from the world's own problems.
+
+SETTLEMENT: ${settlement.name} — ${settlement.description?.substring(0, 300) || 'a settlement'}
+REGION: ${region?.name || 'Unknown'} — ${region?.description?.substring(0, 200) || ''}
+RECENT PLAYER ACTIVITY:
+${recentContext || 'Player just arrived.'}
+
+EXISTING QUESTS (avoid duplicates): ${existingTitles.join(', ') || 'none'}
+
+Generate 1-2 quest seeds. Each quest should:
+- Emerge from the settlement's own problems or conflicts (NOT from the player)
+- Have 2-3 hook variants (ways the narrator can subtly hint at the quest)
+- Have 2-3 objectives (steps to complete the quest)
+- Be completable through multiple approaches (combat, diplomacy, cunning)
+- Feel grounded and logical — no "chosen one" tropes
+
+Hook types: rumor (overheard gossip), observation (something the player notices), npc_mention (an NPC brings it up), environmental (something in the environment hints at it)
+
+Return JSON:
+{
+    "quests": [
+        {
+            "title": "The Missing Shipments",
+            "description": "Trade goods bound for the settlement have been disappearing along the northern road.",
+            "hooks": [
+                { "text": "A merchant grumbles about another missing wagon, the third this month.", "type": "rumor" },
+                { "text": "You notice the market stalls are sparse — fewer goods than you'd expect for a settlement this size.", "type": "observation" }
+            ],
+            "objectives": [
+                { "description": "Learn about the missing shipments from locals", "status": "unknown" },
+                { "description": "Investigate the northern road", "status": "unknown" },
+                { "description": "Deal with the cause of the disappearances", "status": "unknown" }
+            ],
+            "keyActors": [{ "name": "Merchant Harlow", "role": "Quest giver" }]
+        }
+    ]
+}`;
+
+    try {
+        const result = await simplePrompt('gpt-5-mini',
+            'You create RPG quest seeds as JSON. Return valid JSON only.',
+            prompt
+        );
+
+        let jsonContent = result.content;
+        const jsonMatch = jsonContent.match(/```(?:json)?\s*([\s\S]*?)```/);
+        if (jsonMatch) jsonContent = jsonMatch[1].trim();
+
+        const parsed = JSON.parse(jsonContent);
+        const quests = parsed.quests || [];
+        if (!Array.isArray(quests) || quests.length === 0) return [];
+
+        const created = [];
+        for (const q of quests.slice(0, 2)) {
+            const quest = new Quest({
+                world: plot.world,
+                settlement: settlement._id,
+                questTitle: q.title,
+                description: q.description,
+                status: 'seed',
+                hooks: (q.hooks || []).map(h => ({
+                    text: h.text,
+                    type: ['rumor', 'observation', 'npc_mention', 'environmental'].includes(h.type) ? h.type : 'rumor',
+                    delivered: false
+                })),
+                objectives: (q.objectives || []).map((obj, i) => ({
+                    id: `obj_${i}`,
+                    description: obj.description,
+                    status: 'unknown',
+                    isCurrent: i === 0
+                })),
+                keyActors: {
+                    primary: (q.keyActors || []).map(a => ({ name: a.name, role: a.role })),
+                    secondary: []
+                },
+                currentSummary: q.description
+            });
+
+            await quest.save();
+
+            // Link to plot
+            plot.quests.push({
+                quest: quest._id,
+                questTitle: quest.questTitle,
+                questStatus: 'seed',
+                notes: []
+            });
+
+            created.push(quest);
+            console.log(`[Quest] Seed created: "${quest.questTitle}" at ${settlement.name}`);
+        }
+
+        // Update quest state
+        if (!plot.current_state.questState) {
+            plot.current_state.questState = {};
+        }
+        plot.current_state.questState.lastSeedGeneration = new Date();
+        plot.current_state.questState.seedSettlement = settlement._id;
+        await plot.save();
+
+        return created;
+    } catch (e) {
+        console.error('[Quest] generateQuestSeeds failed:', e.message);
+        return [];
+    }
+}
+
+// ============ HOOK DELIVERY ============
+
+/**
+ * Get a hook snippet for the narrator to weave into the current response.
+ * Returns null if no hook is appropriate right now.
+ */
+async function getHooksForNarrative(plotId) {
+    try {
+        const plot = await Plot.findById(plotId);
+        if (!plot) return null;
+
+        const qs = plot.current_state?.questState || {};
+        const turnsSinceHook = qs.turnsSinceLastHook || 0;
+
+        // Rate limit: at least 3 turns between hooks
+        if (turnsSinceHook < 3) {
+            // Increment counter
+            if (!plot.current_state.questState) plot.current_state.questState = {};
+            plot.current_state.questState.turnsSinceLastHook = turnsSinceHook + 1;
+            await plot.save();
+            return null;
+        }
+
+        const settlementId = plot.current_state?.current_location?.settlement;
+        if (!settlementId) return null;
+
+        // Find seed quests at current settlement with undelivered hooks
+        const seedQuests = await Quest.find({
+            world: plot.world,
+            settlement: settlementId,
+            status: 'seed',
+            'hooks.delivered': false
+        });
+
+        if (seedQuests.length === 0) return null;
+
+        // Pick a random quest and its first undelivered hook
+        const quest = seedQuests[Math.floor(Math.random() * seedQuests.length)];
+        const hook = quest.hooks.find(h => !h.delivered);
+        if (!hook) return null;
+
+        // Reset counter (will be set back to 0 when hook is delivered)
+        if (!plot.current_state.questState) plot.current_state.questState = {};
+        plot.current_state.questState.turnsSinceLastHook = 0;
+        await plot.save();
+
+        return hook.text;
+    } catch (e) {
+        console.error('[Quest] getHooksForNarrative error:', e.message);
+        return null;
+    }
+}
+
+// ============ QUEST DISCOVERY ============
+
+/**
+ * Check if the AI's narrative response mentions elements from seed quests.
+ * If so, transition seed → discovered and return newly discovered quests.
+ */
+async function detectQuestDiscovery(plotId, aiResponse) {
+    try {
+        const plot = await Plot.findById(plotId);
+        if (!plot) return [];
+
+        const settlementId = plot.current_state?.current_location?.settlement;
+        if (!settlementId) return [];
+
+        const seedQuests = await Quest.find({
+            world: plot.world,
+            settlement: settlementId,
+            status: 'seed'
+        });
+
+        if (seedQuests.length === 0) return [];
+
+        const responseLower = aiResponse.toLowerCase();
+        const discovered = [];
+
+        for (const quest of seedQuests) {
+            let matched = false;
+
+            // Check if any key actor names appear in the response
+            const actorNames = [
+                ...(quest.keyActors?.primary || []).map(a => a.name),
+                ...(quest.keyActors?.secondary || []).map(a => a.name)
+            ].filter(Boolean);
+
+            for (const name of actorNames) {
+                if (name && responseLower.includes(name.toLowerCase())) {
+                    matched = true;
+                    break;
+                }
+            }
+
+            // Check if hook text appears (fuzzy: check key words)
+            if (!matched) {
+                for (const hook of (quest.hooks || [])) {
+                    if (!hook.text) continue;
+                    // Extract meaningful words (>4 chars) from hook
+                    const words = hook.text.toLowerCase().split(/\s+/).filter(w => w.length > 4);
+                    const matchCount = words.filter(w => responseLower.includes(w)).length;
+                    if (matchCount >= 3) {
+                        matched = true;
+                        // Mark hook as delivered
+                        hook.delivered = true;
+                        hook.deliveredAt = new Date();
+                        break;
+                    }
+                }
+            }
+
+            // Check quest title keywords
+            if (!matched && quest.questTitle) {
+                const titleWords = quest.questTitle.toLowerCase().split(/\s+/).filter(w => w.length > 3);
+                const titleMatchCount = titleWords.filter(w => responseLower.includes(w)).length;
+                if (titleMatchCount >= 2 || (titleWords.length === 1 && titleMatchCount === 1)) {
+                    matched = true;
+                }
+            }
+
+            if (matched) {
+                quest.status = 'discovered';
+                // Set first objective to known
+                if (quest.objectives.length > 0) {
+                    quest.objectives[0].status = 'known';
+                    quest.objectives[0].isCurrent = true;
+                }
+                await quest.save();
+
+                // Sync status in plot
+                const plotQuest = plot.quests.find(q => q.quest?.toString() === quest._id.toString());
+                if (plotQuest) {
+                    plotQuest.questStatus = 'discovered';
+                }
+
+                discovered.push({
+                    id: quest._id.toString(),
+                    title: quest.questTitle,
+                    description: quest.description,
+                    status: 'discovered'
+                });
+
+                console.log(`[Quest] Discovered: "${quest.questTitle}"`);
+            }
+        }
+
+        if (discovered.length > 0) {
+            await plot.save();
+        }
+
+        return discovered;
+    } catch (e) {
+        console.error('[Quest] detectQuestDiscovery error:', e.message);
+        return [];
+    }
+}
+
+// ============ QUEST ACTIVATION ============
+
+/**
+ * Player clicked "Track Quest" — transition discovered → active.
+ */
+async function activateQuest(plotId, questId) {
+    const plot = await Plot.findById(plotId);
+    if (!plot) return { success: false, error: 'Plot not found' };
+
+    const quest = await Quest.findById(questId);
+    if (!quest) return { success: false, error: 'Quest not found' };
+
+    if (quest.status !== 'discovered') {
+        return { success: false, error: `Quest is ${quest.status}, not discovered` };
+    }
+
+    quest.status = 'active';
+    // Set first unknown objective to in_progress
+    for (const obj of quest.objectives) {
+        if (obj.isCurrent && (obj.status === 'unknown' || obj.status === 'known')) {
+            obj.status = 'in_progress';
+            break;
+        }
+    }
+    await quest.save();
+
+    // Update plot
+    plot.activeQuest = quest._id;
+    const plotQuest = plot.quests.find(q => q.quest?.toString() === questId);
+    if (plotQuest) {
+        plotQuest.questStatus = 'active';
+    }
+    await plot.save();
+
+    console.log(`[Quest] Activated: "${quest.questTitle}"`);
+    return { success: true, quest: { id: quest._id, title: quest.questTitle, status: 'active' } };
+}
+
+// ============ QUEST PROGRESS (AI tool) ============
+
+/**
+ * Called by the AI's update_quest tool during gameplay.
+ */
+async function updateQuestProgress(plotId, questTitle, updateType, summary) {
+    const plot = await Plot.findById(plotId);
+    if (!plot) return { success: false, error: 'Plot not found' };
+
+    // Fuzzy title match across plot's quests
+    const titleLower = questTitle.toLowerCase();
+    const plotQuest = plot.quests.find(q => {
+        if (!q.questTitle) return false;
+        const qt = q.questTitle.toLowerCase();
+        return qt === titleLower || qt.includes(titleLower) || titleLower.includes(qt);
+    });
+
+    if (!plotQuest) return { success: false, error: `Quest "${questTitle}" not found` };
+
+    const quest = await Quest.findById(plotQuest.quest);
+    if (!quest) return { success: false, error: 'Quest document not found' };
+
+    // Append progression
+    quest.progression.push({ summary, timestamp: new Date() });
+    quest.currentSummary = summary;
+
+    switch (updateType) {
+        case 'objective_complete': {
+            // Mark current objective as completed, advance to next
+            const current = quest.objectives.find(o => o.isCurrent);
+            if (current) {
+                current.status = 'completed';
+                current.isCurrent = false;
+            }
+            // Find next unknown/known objective
+            const next = quest.objectives.find(o => o.status === 'unknown' || o.status === 'known');
+            if (next) {
+                next.status = 'in_progress';
+                next.isCurrent = true;
+            }
+            break;
+        }
+        case 'quest_complete':
+            quest.status = 'completed';
+            plotQuest.questStatus = 'completed';
+            // Mark all remaining objectives complete
+            quest.objectives.forEach(o => {
+                if (o.status !== 'failed') o.status = 'completed';
+                o.isCurrent = false;
+            });
+            break;
+        case 'quest_failed':
+            quest.status = 'failed';
+            plotQuest.questStatus = 'failed';
+            quest.objectives.forEach(o => {
+                o.isCurrent = false;
+            });
+            break;
+        case 'new_info':
+            // Just the progression append is sufficient
+            break;
+    }
+
+    await quest.save();
+    await plot.save();
+
+    console.log(`[Quest] Updated "${quest.questTitle}": ${updateType} — ${summary}`);
+    return {
+        success: true,
+        quest: {
+            id: quest._id.toString(),
+            title: quest.questTitle,
+            status: quest.status,
+            updateType
+        }
+    };
+}
+
+// ============ CONTEXT FOR NARRATIVE PROMPT ============
+
+/**
+ * Build a text block of quest context to inject into the narrative prompt.
+ */
+async function getQuestContext(plotId) {
+    const plot = await Plot.findById(plotId);
+    if (!plot) return '';
+
+    const questIds = plot.quests
+        .filter(q => q.questStatus === 'active' || q.questStatus === 'discovered')
+        .map(q => q.quest);
+
+    if (questIds.length === 0) return '';
+
+    const quests = await Quest.find({ _id: { $in: questIds } });
+    if (quests.length === 0) return '';
+
+    const parts = [];
+    for (const quest of quests) {
+        if (quest.status === 'active') {
+            const currentObj = quest.objectives.find(o => o.isCurrent);
+            const lastProg = quest.progression.length > 0
+                ? quest.progression[quest.progression.length - 1].summary
+                : null;
+            let line = `ACTIVE QUEST: "${quest.questTitle}"`;
+            if (currentObj) line += ` — Current objective: ${currentObj.description}`;
+            if (lastProg) line += ` — Last update: ${lastProg}`;
+            parts.push(line);
+        } else if (quest.status === 'discovered') {
+            parts.push(`KNOWN LEAD: "${quest.questTitle}" — ${quest.description?.substring(0, 150) || ''}`);
+        }
+    }
+
+    return parts.length > 0 ? '\nQUEST CONTEXT:\n' + parts.join('\n') + '\n' : '';
+}
+
+// ============ JOURNAL ENDPOINT ============
+
+/**
+ * Return all quests visible to the player (status !== 'seed').
+ */
+async function getJournalQuests(plotId) {
+    const plot = await Plot.findById(plotId);
+    if (!plot) return [];
+
+    const questIds = plot.quests.map(q => q.quest);
+    if (questIds.length === 0) return [];
+
+    const quests = await Quest.find({
+        _id: { $in: questIds },
+        status: { $ne: 'seed' }
+    }).sort({ updatedAt: -1 });
+
+    return quests.map(q => ({
+        id: q._id.toString(),
+        title: q.questTitle,
+        description: q.description,
+        status: q.status,
+        currentSummary: q.currentSummary,
+        objectives: q.objectives,
+        progression: q.progression.slice(-5), // last 5 entries
+        keyActors: q.keyActors
+    }));
+}
+
+// ============ EXPIRATION ============
+
+/**
+ * Expire stale quests. Called on area transitions.
+ */
+async function expireStaleQuests(plotId) {
+    try {
+        const plot = await Plot.findById(plotId);
+        if (!plot) return;
+
+        const turnCount = plot.current_state?.sceneContext?.turnCount || 0;
+
+        // Find old seeds (linked to this plot's world)
+        const staleSeeds = await Quest.find({
+            world: plot.world,
+            status: 'seed',
+            createdAt: { $lt: new Date(Date.now() - 1000 * 60 * 60 * 24) } // >24h old
+        });
+
+        for (const quest of staleSeeds) {
+            quest.status = 'expired';
+            await quest.save();
+
+            const plotQuest = plot.quests.find(q => q.quest?.toString() === quest._id.toString());
+            if (plotQuest) plotQuest.questStatus = 'expired';
+
+            console.log(`[Quest] Expired stale seed: "${quest.questTitle}"`);
+        }
+
+        if (staleSeeds.length > 0) {
+            await plot.save();
+        }
+    } catch (e) {
+        console.error('[Quest] expireStaleQuests error:', e.message);
+    }
+}
+
+module.exports = {
+    shouldGenerateSeeds,
+    generateQuestSeeds,
+    getHooksForNarrative,
+    detectQuestDiscovery,
+    activateQuest,
+    updateQuestProgress,
+    getQuestContext,
+    getJournalQuests,
+    expireStaleQuests
+};


### PR DESCRIPTION
## Summary
- Replace pre-generated startup quests with an emergent quest lifecycle: `seed → discovered → active → completed/failed/expired`
- Seeds generate in the background via probability (15% base, boosted/dampened by game state — no quests = faster seeds, many active = slower)
- Hooks are woven into narration by the AI (rate-limited every 3 turns), and discovery happens through fuzzy text matching when the AI mentions quest elements
- Players activate quests via "Track Quest" button — the AI never forces quest tracking
- New `questService.js` with 9 core functions for the full quest lifecycle
- Quest journal modal replaces old static quest list (Active / Leads / Completed sections)
- Inline quest discovery cards appear in the game log with amber styling
- AI `update_quest` tool allows progress tracking on active quests
- Removed startup `getInitialQuests` call — games load faster

## Files Changed
| File | Changes |
|------|---------|
| `services/questService.js` | **NEW** — all quest logic (seed gen, hooks, discovery, activation, progress, journal, expiration) |
| `db/models/Quest.js` | New status enum, hooks, progression, objectives, settlement ref |
| `db/models/Plot.js` | questState in current_state, questStatus enum on quests[] |
| `db/models/GameLog.js` | questUpdates field for reload persistence |
| `services/gameAgent.js` | update_quest tool, quest context/hook injection, background seed gen, quest discovery in Promise.all |
| `routes/plots.js` | Removed init quests, added GET /quests + POST /quests/:id/track |
| `routes/gameLogs.js` | quest_discovered + quest_update SSE relay |
| `public/app.js` | Quest journal modal, SSE handlers, discovery cards, removed dead code |
| `public/index.html` | Quest journal modal structure |
| `public/styles.css` | Quest journal + discovery card CSS |

## Test plan
- [ ] Start new game — should load faster (no quest gen blocking)
- [ ] Play 5+ turns — check MongoDB for Quest docs with `status: 'seed'`
- [ ] Continue playing — AI should weave subtle hooks into narration
- [ ] When hook lands — quest discovery card appears inline in game log
- [ ] Click "Track Quest" — quest appears in journal as Active with objectives
- [ ] Open quest journal — shows Active quests and any untracked Leads
- [ ] Continue playing — AI uses `update_quest` tool to log progress
- [ ] Page reload — quest discovery cards persist via questUpdates in GameLog

🤖 Generated with [Claude Code](https://claude.com/claude-code)